### PR TITLE
Small improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ serde_json = "1.0"
 serde = {version = "1.0", features = ["derive"]}
 chrono = {version = "0.4", features = [ "serde" ]}
 uuid = {version = "1.2", features = ["serde", "v4"]}
-dotenv = {version = "0.15"}
 num-derive = {version = "0.3"}
 
 diesel = { version = "2.0", features = ["postgres", "r2d2", "chrono", "uuid"]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@
 #![warn(rustdoc::broken_intra_doc_links)]
 #[macro_use]
 extern crate diesel;
-extern crate dotenv;
 extern crate num_derive;
 
 ///

--- a/src/management/mod.rs
+++ b/src/management/mod.rs
@@ -109,7 +109,7 @@ impl Serialize for Station {
     where
         S: Serializer,
     {
-        let mut s = serializer.serialize_struct("Station", 15).unwrap();
+        let mut s = serializer.serialize_struct("Station", 15)?;
 
         s.serialize_field("id", &self.id)?;
         s.serialize_field("name", &self.name)?;

--- a/src/measurements.rs
+++ b/src/measurements.rs
@@ -34,7 +34,67 @@ pub struct FinishedMeasurementInterval {
     pub region: i64,
 }
 
+#[allow(missing_docs)] // allowed since enum variants are pretty self-explanatory
+/// This enum signifies error during conversion of [`MeasurementInterval`] into
+/// [`FinishedMeasurementInterval`]. Variants are pretty self-explanatory
+pub enum MeasuerementIntervalError {
+    MissingStartValue,
+    MissingStopValue,
+    MissingLineValue,
+    MissingRunValue,
+    MissingRegionValue,
+}
+
+impl TryFrom<MeasurementInterval> for FinishedMeasurementInterval {
+    type Error = MeasuerementIntervalError;
+    fn try_from(val: MeasurementInterval) -> Result<Self, Self::Error> {
+        // match every value, if any of them is None, return corresponding error
+        let start = match val.start {
+            Some(v) => v,
+            None => {
+                return Err(MeasuerementIntervalError::MissingStartValue);
+            }
+        };
+        let stop = match val.stop {
+            Some(v) => v,
+            None => {
+                return Err(MeasuerementIntervalError::MissingStopValue);
+            }
+        };
+        let line = match val.line {
+            Some(v) => v,
+            None => {
+                return Err(MeasuerementIntervalError::MissingLineValue);
+            }
+        };
+        let run = match val.run {
+            Some(v) => v,
+            None => {
+                return Err(MeasuerementIntervalError::MissingRunValue);
+            }
+        };
+        let region = match val.region {
+            Some(v) => v,
+            None => {
+                return Err(MeasuerementIntervalError::MissingRegionValue);
+            }
+        };
+
+        Ok(FinishedMeasurementInterval {
+            start,
+            stop,
+            line,
+            run,
+            region,
+        })
+    }
+}
+
 impl FinishedMeasurementInterval {
+    #[deprecated(
+        since = "0.8.1",
+        note = "Please use TryFrom<MeasurementInterval> trait from now on!"
+    )]
     /// Converts the intermediate representation into the final measurement.
     pub fn from_measurement(measurement: MeasurementInterval) -> FinishedMeasurementInterval {
         FinishedMeasurementInterval {


### PR DESCRIPTION
This is a draft for now, where some smol rough edges are removed.

## Things Changed

### General
Removed not used crates

### Fixing #13 

- added: conversion between `MeasurementInterval` and `FinishedMeasurementInterval` is now handled by the `TryFrom` trait. Custom error type returned on failure instead of a panic.
- In view of the point above, `FinishedMeasurementInterval::from_measurement` is now deprecated, to be removed in next major verson
- Serializer for `Station`: propogate error up instead of panic


## Required Doc/Changelog Updates

- [ ] **I HAVE UPDATED CHANGELOG ACCORDINGLY**
- [ ] **I HAVE UPDATED DOCS ACCORDINGLY**
